### PR TITLE
Add icon.fieldValues to accept multiple field values for displaying icon

### DIFF
--- a/src/scripts/rx-data-table.src.js
+++ b/src/scripts/rx-data-table.src.js
@@ -413,6 +413,8 @@ app.directive('rxDataTable', function ($http, $timeout, $document, $filter, $par
                         } else if (icon.fieldValue === this.row[icon.field]) {
                             return true;
                         }
+                    } if (_.has(icon, 'fieldValues')) {
+                        return _.isArray(icon.fieldValues) && _.contains(icon.fieldValues, this.row[icon.field]);
                     } else if (row[icon.field] === true) {
                         return true;
                     } else if (_.has(icon, 'fieldMinLength') && _.isArray(row[icon.field])) {


### PR DESCRIPTION
we could have this way to reduce array of icons in column config

**without `fieldValues` field**
```yaml
icon:
  - field: status
    fieldValue: New
    name: fa fa-sort-desc
    tooltip:
      text: Edit Status

  - field: status
    fieldValue: Pending Maintenace
    name: fa fa-sort-desc
    tooltip:
      text: Edit Status
```

**with `fieldValues` field**
```yaml
 icon:
  - field: status
    fieldValues:
        - New
        - Pending Maintenace
    name: fa fa-sort-desc
    tooltip:
      text: Edit Status
```